### PR TITLE
Whitelist some syscalls used in libpcap

### DIFF
--- a/src/sandbox/seccomp.rs
+++ b/src/sandbox/seccomp.rs
@@ -102,6 +102,9 @@ pub fn activate_stage1() -> Result<(), SeccompError> {
     ctx.allow_syscall(Syscall::openat)?;
     ctx.allow_syscall(Syscall::seccomp)?; // needed for stage2
     ctx.allow_syscall(Syscall::getrandom)?;
+    ctx.allow_syscall(Syscall::rt_sigprocmask)?; // used in libpcap
+    ctx.allow_syscall(Syscall::pipe)?;
+    ctx.allow_syscall(Syscall::wait4)?;
 
     ctx.load()?;
 

--- a/src/sandbox/syscalls.rs
+++ b/src/sandbox/syscalls.rs
@@ -52,6 +52,9 @@ pub enum Syscall {
     openat              = libc::SYS_openat              as isize,
     seccomp             = libc::SYS_seccomp             as isize,
     getrandom           = libc::SYS_getrandom           as isize,
+    rt_sigprocmask      = libc::SYS_rt_sigprocmask      as isize,
+    pipe                = libc::SYS_pipe                as isize,
+    wait4               = libc::SYS_wait4               as isize,
 }
 
 impl Syscall {


### PR DESCRIPTION
Hey,

I just tried `sniffglue` and it aborted with
```
$ strace sniffglue
...
rt_sigprocmask(SIG_BLOCK, [CHLD],  <unfinished ...>) = ?
+++ killed by SIGSYS (core dumped) +++
fish: “sudo strace sniffglue” terminated by signal SIGSYS (Bad system call)
```
It looks like the syscall `rt_sigprocmask` and some others are called from [inside](https://github.com/the-tcpdump-group/libpcap/blob/master/pcap.c#L2363) [libpcap](https://github.com/the-tcpdump-group/libpcap/blob/master/pcap.c#L3112) and trapped by seccomp.

Whitelisting the `rt_sigprocmask`, `pipe` and `wait4` syscalls fixes the issues on my system (`libpcap 1.8.2`, `4.13.11-1-ARCH`).
<details>
<summary>Core dump backtrace</summary>

    Nov 12 23:57:35 systemd-coredump[15348]: Process 15345 (sniffglue) of user 0 dumped core.
                                                  
                                                  Stack trace of thread 15345:
                                                  #0  0x00007f3b1bd0fb50 sigprocmask (libc.so.6)
                                                  #1  0x00007f3b1b34e925 n/a (libdbus-1.so.3)
                                                  #2  0x00007f3b1b342d98 n/a (libdbus-1.so.3)
                                                  #3  0x00007f3b1b342c12 n/a (libdbus-1.so.3)
                                                  #4  0x00007f3b1b32c636 n/a (libdbus-1.so.3)
                                                  #5  0x00007f3b1b327e99 n/a (libdbus-1.so.3)
                                                  #6  0x00007f3b1cb2674f n/a (libpcap.so.1)
                                                  #7  0x00007f3b1cb27aed pcap_activate (libpcap.so.1)
                                                  #8  0x00007f3b1cb28a98 n/a (libpcap.so.1)
                                                  #9  0x00007f3b1cb28fdd n/a (libpcap.so.1)
                                                  #10 0x00007f3b1cb268e3 n/a (libpcap.so.1)
                                                  #11 0x00007f3b1cb26f64 pcap_findalldevs (libpcap.so.1)
                                                  #12 0x00007f3b1cb28534 pcap_lookupdev (libpcap.so.1)
                                                  #13 0x000055e0d7017b92 n/a (/home/mrmaxmeier/.cargo/bin/sniffglue)
</details>
