### PR TITLE
Add cargo-deb support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,19 @@ categories = ["command-line-utilities"]
 readme = "README.md"
 exclude = ["pcaps/**/*", "**/*.pcap"]
 
+[package.metadata.deb]
+license-file = [ "LICENSE" ]
+extended-description = """\
+sniffglue is a network sniffer written in rust. Network packets are parsed \
+concurrently using a thread pool to utilize all cpu cores. Project goals are \
+that you can run sniffglue securely on untrusted networks and that it must \
+not crash when processing packets. The output should be as useful as possible \
+by default.\
+"""
+depends = "$auto"
+section = "net"
+priority = "optional"
+
 [lib]
 doc = false
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Archlinux: `libpcap libseccomp`.
 
     cargo install sniffglue
 
+Or you can build a Debian package via [cargo-deb](https://github.com/mmstick/cargo-deb):
+
+    cargo deb
+
 ## Protocols
 
 - [X] ethernet


### PR DESCRIPTION
This is a basic cargo-deb support; I'll add the manpage once mmstick/cargo-deb#97 is resolved (if I remember why I have opened this issue ...).