### PR TITLE
Support for writing out to a pcap file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,14 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -789,6 +797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcap-file"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1217,7 @@ dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pcap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pcap-file 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pktparse 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reduce 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1816,6 +1834,7 @@ dependencies = [
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -1865,6 +1884,7 @@ dependencies = [
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum pcap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f912b9e56d1d4851a5175c118fc6503c9f69a8fe1a0649a51aff20b92c757491"
+"checksum pcap-file 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5b729899fae3ba1ac9de3bd360829a3845a815b1396047ea1dc5e18a70fd47"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "kpcyrd/sniffglue" }
 structopt = "0.2"
 threadpool = "1.7"
 num_cpus = "1.6"
-pcap = "0.7.0"
+pcap = { version = "0.7.0", features = ["pcap-savefile-append"] }
 pktparse = { version = "0.4", features = ["derive"] }
 nom = "4.0"
 dns-parser = "0.8"
@@ -39,6 +39,7 @@ nix = "0.14"
 sha2 = "0.8"
 dirs = "2.0"
 base64 = "0.10"
+pcap-file = "0.10.0"
 
 [target.'cfg(target_os="linux")'.dependencies]
 syscallz = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "kpcyrd/sniffglue" }
 structopt = "0.2"
 threadpool = "1.7"
 num_cpus = "1.6"
-pcap = { version = "0.7.0", features = ["pcap-savefile-append"] }
+pcap = "0.7.0"
 pktparse = { version = "0.4", features = ["derive"] }
 nom = "4.0"
 dns-parser = "0.8"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,9 @@ pub struct Args {
     /// Open device as pcap file
     #[structopt(short="r", long="read")]
     pub read: bool,
+    /// Output pcap file path
+    #[structopt(short="o", long="output")]
+    pub output: Option<String>,
     /// Number of cores
     #[structopt(short="n", long="cpus")]
     pub cpus: Option<usize>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,11 +176,9 @@ fn main() {
                 if filter.matches(&parsed_packet) {
                     //temporarily write it out to file
                     tx.send(parsed_packet).unwrap();
-                    // if the user wants a pcap output then parse that and send
-                    // it
                     if is_pcap {
                         let pcap_pkt = Packet::new_owned(sec, usec, packet_data.len() as u32, packet_data);
-                        pcap_tx.send(pcap_pkt);
+                        pcap_tx.send(pcap_pkt).unwrap();
                     }
                 }
             });


### PR DESCRIPTION
Before, there was not the ability to output to a pcap formatted file that can be opened by tools like `wireshark`. This PR adds that support through a new `-o` or `--output` flag that allows specifying a pcap output file. It follows with the existing structure (conforming to the verbosity levels) and has no extra parsing overhead if the user does not use the flag. 