### PR TITLE
Try to detect tls and http more aggressively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1270,7 +1270,7 @@ dependencies = [
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syscallz 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syscallz 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tls-parser 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1388,11 +1388,12 @@ dependencies = [
 
 [[package]]
 name = "syscallz"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "seccomp-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1424,11 +1425,10 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2046,11 +2046,11 @@ dependencies = [
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum syscallz 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4614a8b1e31c3a88c1f28c77ad86d023858f42e9184c98f55eee752a4c0cedb7"
+"checksum syscallz 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "50705b7ea2988f5ffe44385fa9e1cd43bac2df6aa9695c2a4bed319ba2f03bbc"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum tls-parser 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "584f843a20dca9f22cb9bd21ab6026e3183ba281a7820c0d8a0a373f956187c6"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ base64 = "0.12"
 libc = "0.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
-syscallz = "0.13"
+syscallz = "0.13.2"
 #syscallz = { path="../syscallz-rs" }
 
 [dev-dependencies]

--- a/src/centrifuge/tcp.rs
+++ b/src/centrifuge/tcp.rs
@@ -22,17 +22,14 @@ pub fn parse(remaining: &[u8]) -> Result<(tcp::TcpHeader, TCP), CentrifugeError>
 }
 
 #[inline]
-pub fn extract(tcp_hdr: &TcpHeader, remaining: &[u8]) -> Result<TCP, CentrifugeError> {
+pub fn extract(_tcp_hdr: &TcpHeader, remaining: &[u8]) -> Result<TCP, CentrifugeError> {
     if remaining.is_empty() {
         Ok(TCP::Empty)
-    } else if tcp_hdr.dest_port == 443 {
-        let client_hello = tls::extract(remaining)?;
+    } else if let Ok(client_hello) = tls::extract(remaining) {
         Ok(TCP::TLS(client_hello))
-    } else if tcp_hdr.source_port == 443 {
-        let server_hello = tls::extract(remaining)?;
+    } else if let Ok(server_hello) = tls::extract(remaining) {
         Ok(TCP::TLS(server_hello))
-    } else if tcp_hdr.dest_port == 80 {
-        let http = http::extract(remaining)?;
+    } else if let Ok(http) = http::extract(remaining) {
         Ok(TCP::HTTP(http))
     } else {
         Err(CentrifugeError::UnknownProtocol)


### PR DESCRIPTION
Also resolves a seccomp issue that was introduced in the last few commits by updating `syscallz`.