### PR TITLE
Add install instructions for GNU Guix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ key for this repository out of the debian keyring.
 
     nix-env -i sniffglue
 
+### GNU Guix
+
+    guix install sniffglue
+
 ### From source
 
 To build from source make sure you have libpcap and libseccomp installed. On


### PR DESCRIPTION
I packaged sniffglue for [GNU Guix](https://guix.gnu.org/) (like Nix/NixOS). It can now be installed via `guix install sniffglue`. This commit adds that information to the install section in the README.