### PR TITLE
Adjust tests to match pktparse 0.7.1 behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,9 +560,9 @@ checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "pktparse"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6dd3070cf6f4d7cfb77aade4509979246a245b8a356eec51803ba92c7d21e6"
+checksum = "a8aeb7ec35e7fdd2ecd56d39d56f843197f243d08cc4d51cf6b37268393d5e1b"
 dependencies = [
  "nom",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ structopt = "0.3"
 anyhow = "1"
 num_cpus = "1.6"
 pcap-sys = "0.1.3"
-pktparse = { version = "0.7", features = ["serde"] }
+pktparse = { version = "0.7.1", features = ["serde"] }
 nom = "7"
 dns-parser = "0.8"
 tls-parser = "0.11"

--- a/src/centrifuge/sll.rs
+++ b/src/centrifuge/sll.rs
@@ -55,7 +55,7 @@ mod tests {
             Ether::IPv4(
                 IPv4Header {
                     version: 4,
-                    ihl: 20,
+                    ihl: 5,
                     tos: 0,
                     length: 94,
                     id: 63161,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ mod tests {
             },
             IPv4(IPv4Header {
                 version: 4,
-                ihl: 20,
+                ihl: 5,
                 tos: 0,
                 length: 442,
                 id: 20073,


### PR DESCRIPTION
https://github.com/bestouff/pktparse-rs/commit/d0db75eccb77ae6898804c92a3b2806353657522
changed how the IHL header is reported.  Update the tests accordingly
and bump the pktparse dependency to 0.7.1.