### PR TITLE
Add support for LoongArch64

### DIFF
--- a/src/sandbox/seccomp.rs
+++ b/src/sandbox/seccomp.rs
@@ -7,24 +7,44 @@ pub fn activate_stage1() -> Result<()> {
     ctx.allow_syscall(Syscall::futex)?;
     ctx.allow_syscall(Syscall::read)?;
     ctx.allow_syscall(Syscall::write)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::open)?;
     ctx.allow_syscall(Syscall::close)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::stat)?;
     #[cfg(target_arch = "arm")]
     ctx.allow_syscall(Syscall::stat64)?;
     ctx.allow_syscall(Syscall::fstat)?;
     #[cfg(target_arch = "arm")]
     ctx.allow_syscall(Syscall::fstat64)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::lstat)?;
     #[cfg(target_arch = "arm")]
     ctx.allow_syscall(Syscall::lstat64)?;
     ctx.allow_syscall(Syscall::statx)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::poll)?;
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    ))]
     ctx.allow_syscall(Syscall::ppoll)?;
     ctx.allow_syscall(Syscall::lseek)?; // needed for stage2
     #[cfg(target_arch = "arm")]
@@ -58,7 +78,11 @@ pub fn activate_stage1() -> Result<()> {
     ctx.allow_syscall(Syscall::fcntl)?;
     #[cfg(target_arch = "arm")]
     ctx.allow_syscall(Syscall::fcntl64)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::getdents)?;
     ctx.allow_syscall(Syscall::chdir)?; // needed for stage2
     ctx.allow_syscall(Syscall::getuid)?; // needed for stage2
@@ -102,11 +126,20 @@ pub fn activate_stage1() -> Result<()> {
     ctx.allow_syscall(Syscall::exit_group)?;
     ctx.allow_syscall(Syscall::set_robust_list)?;
     ctx.allow_syscall(Syscall::openat)?;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    ))]
     ctx.allow_syscall(Syscall::newfstatat)?;
     ctx.allow_syscall(Syscall::seccomp)?; // needed for stage2
     ctx.allow_syscall(Syscall::getrandom)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::pipe)?; // used in libpcap
     ctx.allow_syscall(Syscall::wait4)?;
     ctx.allow_syscall(Syscall::clock_gettime)?;
@@ -117,7 +150,11 @@ pub fn activate_stage1() -> Result<()> {
     ctx.allow_syscall(Syscall::brk)?;
     ctx.allow_syscall(Syscall::madvise)?;
     ctx.allow_syscall(Syscall::membarrier)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::access)?; // needed for debian /etc/ld.so.nohwcap
     ctx.allow_syscall(Syscall::faccessat)?; // needed for debian /etc/ld.so.nohwcap
     ctx.allow_syscall(Syscall::eventfd2)?;
@@ -145,9 +182,17 @@ pub fn activate_stage2() -> Result<()> {
     // ctx.allow_syscall(Syscall::stat)?;
     // ctx.allow_syscall(Syscall::fstat)?;
     // ctx.allow_syscall(Syscall::lstat)?;
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.allow_syscall(Syscall::poll)?;
-    #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    ))]
     ctx.allow_syscall(Syscall::ppoll)?;
     #[cfg(not(target_arch = "arm"))]
     ctx.allow_syscall(Syscall::mmap)?;
@@ -200,7 +245,12 @@ pub fn activate_stage2() -> Result<()> {
 
     // /proc/sys/vm/overcommit_memory
     ctx.set_action_for_syscall(Action::Errno(1), Syscall::openat)?;
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))]
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    )))]
     ctx.set_action_for_syscall(Action::Errno(1), Syscall::open)?;
 
     ctx.load()?;


### PR DESCRIPTION
This PR adds support for [LoongArch64](https://doc.rust-lang.org/rustc/platform-support/loongarch-linux.html). (A Tier-2 target)