### PR TITLE
Refactor packet handling and thread management

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use sniffglue::sandbox;
 use sniffglue::sniff;
 use sniffglue::structs;
 use std::io::{self, IsTerminal, stdout};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
@@ -27,7 +28,7 @@ fn main() -> Result<()> {
     sandbox::activate_stage1(args.insecure_disable_seccomp)
         .context("Failed to init sandbox stage1")?;
 
-    let device = if let Some(dev) = args.device {
+    let device = if let Some(dev) = args.device.take() {
         dev
     } else {
         sniff::default_interface().context("Failed to find default interface")?
@@ -44,12 +45,17 @@ fn main() -> Result<()> {
     let colors = io::stdout().is_terminal();
     let config = fmt::Config::new(layout, args.verbose, colors);
 
-    let cap = if args.read {
+    
+    let filter = config.filter();
+
+    let is_file_read = args.read;
+
+    let cap = if is_file_read {
+       
         if args.threads.is_none() {
             debug!("Setting thread default to 1 due to -r");
             args.threads = Some(1);
         }
-
         let cap = sniff::open_file(&device)?;
         eprintln!("Reading from file: {:?}", device);
         cap
@@ -61,56 +67,107 @@ fn main() -> Result<()> {
                 immediate_mode: true,
             },
         )?;
-
-        let verbosity = config.filter().verbosity;
+        
+        if args.threads.is_none() {
+            debug!("Defaulting to 1 thread for live capture (acquisition is serialized)");
+            args.threads = Some(1);
+        }
         eprintln!(
             "Listening on device: {:?}, verbosity {}/4",
-            device, verbosity
+            device,
+            filter.verbosity
         );
         cap
     };
 
-    let threads = args.threads.unwrap_or_else(num_cpus::get);
+    let threads = args.threads.unwrap_or(1);
     debug!("Using {} threads", threads);
 
     let datalink = DataLink::from_linktype(cap.datalink())?;
 
-    let filter = config.filter();
-    let (tx, rx) = mpsc::sync_channel(256);
+    
+    let (tx, rx) = mpsc::sync_channel::<structs::raw::Packet>(256);
     let cap = Arc::new(Mutex::new(cap));
+
+    
+    let done = Arc::new(AtomicBool::new(false));
+
+    
+    let packet_count = Arc::new(AtomicU64::new(0));
 
     sandbox::activate_stage2(args.insecure_disable_seccomp)
         .context("Failed to init sandbox stage2")?;
+
+    let mut handles = Vec::with_capacity(threads);
 
     for _ in 0..threads {
         let cap = cap.clone();
         let datalink = datalink.clone();
         let filter = filter.clone();
         let tx = tx.clone();
-        thread::spawn(move || {
+        let done = done.clone();
+        let packet_count = packet_count.clone();
+
+        let handle = thread::spawn(move || {
             loop {
+                // Check if another thread already hit EOF — avoid hammering a
+                // dead capture with lock attempts.
+                if done.load(Ordering::Relaxed) {
+                    break;
+                }
+
                 let packet = {
                     let mut cap = cap.lock().unwrap();
                     cap.next_pkt()
                 };
 
-                if let Ok(Some(packet)) = packet {
-                    let packet = centrifuge::parse(&datalink, &packet.data);
-                    if filter.matches(&packet) {
-                        tx.send(packet).unwrap()
+                match packet {
+                    Ok(Some(packet)) => {
+                        let parsed = centrifuge::parse(&datalink, &packet.data);
+                        if filter.matches(&parsed) {
+                            packet_count.fetch_add(1, Ordering::Relaxed);
+                            // If receiver hung up, shut down gracefully instead of panic
+                            if tx.send(parsed).is_err() {
+                                debug!("Receiver dropped, shutting down worker thread");
+                                break;
+                            }
+                        }
                     }
-                } else {
-                    debug!("End of packet stream, shutting down reader thread");
-                    break;
+                    Ok(None) => {
+                        debug!("End of packet stream, shutting down reader thread");
+                        // Signal all other threads to stop
+                        done.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                    Err(e) => {
+                        debug!("Packet read error: {}, shutting down reader thread", e);
+                        done.store(true, Ordering::Relaxed);
+                        break;
+                    }
                 }
             }
         });
+
+        handles.push(handle);
     }
+
+    
     drop(tx);
 
     let format = config.format();
     for packet in rx.iter() {
         format.print(packet);
+    }
+
+    
+    for handle in handles {
+        let _ = handle.join();
+    }
+
+    
+    if is_file_read {
+        let count = packet_count.load(Ordering::Relaxed);
+        eprintln!("Done. {} packet(s) matched and displayed.", count);
     }
 
     Ok(())


### PR DESCRIPTION
Original:
if let Ok(Some(packet)) = packet {

This pattern silently drops Err(_) and Ok(None) in the same branch. A read error and EOF look identical both just break the loop with no distinction. If pcap throws an error mid-capture, you get zero indication.

Fix:
match packet {
    Ok(Some(packet)) => { /* parse and send */ }
    Ok(None) => {
        debug!("EOF reached, shutting down thread");
        done.store(true, Ordering::Relaxed);
        break;
    }
    Err(e) => {
        debug!("Read error: {}, shutting down thread", e);
        done.store(true, Ordering::Relaxed);
        break;
    }
}

2. Worker thread panics if receiver drops
Original:
tx.send(packet).unwrap()

If the main thread panics or the receiver gets dropped for any reason, every worker thread panics too via unwrap(). These panics are silent they don't surface in main().

Fix:
if tx.send(parsed).is_err() {
    debug!("Receiver dropped, shutting down worker");
    break;
}

3. No cross-thread EOF signaling
Original:
Each thread independently breaks on Ok(None). The other threads have no idea they keep locking the mutex and calling next_pkt() on an already-exhausted capture. How the pcap backend behaves after EOF isn't guaranteed.

Fix:
let done = Arc::new(AtomicBool::new(false));

if done.load(Ordering::Relaxed) {
    break;
}
done.store(true, Ordering::Relaxed);
break;

First thread to see EOF signals all others. No more hammering a dead capture.

4. num_cpus::get() for live capture makes no sense
Original:
let threads = args.threads.unwrap_or_else(num_cpus::get);

Packet acquisition is fully serialized through Mutex<cap>. Spawning 8 threads on an 8-core machine means 7 threads are always waiting on the lock. The only work that actually parallelizes is centrifuge::parse(). For typical traffic volumes this is not the bottleneck. The -r (file read) path already overrides to 1 the same reasoning applies to live capture.


Fix:

if args.threads.is_none() {
    args.threads = Some(1);
}


if args.threads.is_none() {
    args.threads = Some(1);
}

let threads = args.threads.unwrap_or(1);
If a user explicitly passes --threads 4 for heavy parse workloads, it still works. The default just stops lying about parallelism.


5. config.filter() called twice
Original:
rustlet verbosity = config.filter().verbosity; 
eprintln!("Listening on device: {:?}, verbosity {}/4", device, verbosity);


let filter = filter.clone();

filter is derived via config.filter() in the thread loop setup, and then config.filter().verbosity is called separately just for the eprintln. Two calls producing the same value.
Fix:
let filter = config.filter(); 

eprintln!("Listening on device: {:?}, verbosity {}/4", device, filter.verbosity);

let filter = filter.clone();

6. Worker threads are never joined
Original:
Threads are spawned and forgotten. main() exits after draining rx, but the workers might still be mid-execution. Rust's runtime will kill them but you lose any panic info and get non-deterministic shutdown.

Fix:
let mut handles = Vec::with_capacity(threads);

let handle = thread::spawn(move || { ... });
handles.push(handle);

for handle in handles {
    let _ = handle.join();
}

7. Zero observability on exit for file reads
Original:
When reading a pcap file with -r, the process just silently exits after processing. No count, no confirmation, nothing. Useless for scripting or debugging.

Fix:
rustlet packet_count = Arc::new(AtomicU64::new(0));

packet_count.fetch_add(1, Ordering::Relaxed);


if is_file_read {
    eprintln!("Done. {} packet(s) matched.", packet_count.load(Ordering::Relaxed));
}

AtomicU64 with Relaxed ordering no locks, no contention, effectively free.
